### PR TITLE
Fixing syntax error

### DIFF
--- a/example.php
+++ b/example.php
@@ -11,7 +11,7 @@ require 'vendor/autoload.php';
 // Or configure the Statsd connection with a block
 $opcache = new Opcache\Status(function() {
 
-  $c   = new \\Domnikl\Statsd\Connection\UdpSocket("127.0.0.1", "8125");
+  $c   = new \Domnikl\Statsd\Connection\UdpSocket("127.0.0.1", "8125");
   return new \Domnikl\Statsd\Client($c, "opcache");
 
 });


### PR DESCRIPTION
`PHP Parse error:  syntax error, unexpected '\' (T_NS_SEPARATOR), expecting identifier (T_STRING) in example.php on line 14`
